### PR TITLE
Update README to point to latest JS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also use the SDK by adding this script to your HTML:
 
 ```js
 
-<script type="text/javascript" src="https://sdk.clarifai.com/js/clarifai-2.0.9.js"></script>
+<script type="text/javascript" src="https://sdk.clarifai.com/js/clarifai-latest.js"></script>
 <script>
   var app = new Clarifai.App(
     '{clientId}',


### PR DESCRIPTION
I was trying to use custom languages on models with the 2.0.9 build as stated in the README to no avail. After browsing the source, I figured the language support was added in 2.1.2.

This pull request points to the latest JS build to avoid such confusion. 