### PR TITLE
run integration and unit tests separately

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ const rename = require('gulp-rename');
 const insert = require('gulp-insert');
 const eslint = require('gulp-eslint');
 const jasmine = require('gulp-jasmine');
+const merge = require('merge-stream');
 const del = require('del');
 const VERSION = require('./package.json').version;
 
@@ -118,18 +119,22 @@ function failOnError() {
 }
 
 gulp.task('test', function() {
-  return gulp.src('./tests/*/*.js')
-    .pipe(jasmine({
-      'includeStackTrace': false,
-      'verbose': true,
-      'timeout': 60000,
-      'config': {
-        'helpers': [
-          './node_modules/babel-register/lib/node.js'
-        ],
-        'random': false,
-      }
-    }));
+  var testsFiles = ['./tests/integration*.js', './tests/unit/*.js'];
+  var tests = testsFiles.map(function (element) {
+    return gulp.src(element)
+      .pipe(jasmine({
+        'includeStackTrace': false,
+        'verbose': true,
+        'timeout': 60000,
+        'config': {
+          'helpers': [
+            './node_modules/babel-register/lib/node.js'
+          ],
+          'random': false,
+        }
+      }));
+  });
+  return merge(tests);
 });
 
 gulp.task('unittest', (done, error) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,23 +118,20 @@ function failOnError() {
     }));
 }
 
-gulp.task('test', function() {
-  var testsFiles = ['./tests/integration*.js', './tests/unit/*.js'];
-  var tests = testsFiles.map(function (element) {
-    return gulp.src(element)
-      .pipe(jasmine({
-        'includeStackTrace': false,
-        'verbose': true,
-        'timeout': 60000,
-        'config': {
-          'helpers': [
-            './node_modules/babel-register/lib/node.js'
-          ],
-          'random': false,
-        }
-      }));
-  });
-  return merge(tests);
+gulp.task('test', gulp.series('unittest', 'integrationtest'));
+
+gulp.task('integrationtest', function() {
+  return gulp.src('./tests/integration/*.js')
+    .pipe(jasmine({
+      'includeStackTrace': true,
+      'verbose': true,
+      'timeout': 60000,
+      'config': {
+        'helpers': [
+          './node_modules/babel-register/lib/node.js'
+        ]
+      }
+    }));
 });
 
 gulp.task('unittest', (done, error) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,8 +117,6 @@ function failOnError() {
     }));
 }
 
-gulp.task('test', gulp.series('unittest', 'integrationtest'));
-
 gulp.task('integrationtest', function() {
   return gulp.src('./tests/integration/*.js')
     .pipe(jasmine({
@@ -146,6 +144,8 @@ gulp.task('unittest', (done, error) => {
       }
     }));
 });
+
+gulp.task('test', gulp.series('unittest', 'integrationtest'));
 
 gulp.task('jslint', function() {
   const buildVars = getBuildVars();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -120,13 +120,14 @@ function failOnError() {
 gulp.task('integrationtest', function() {
   return gulp.src('./tests/integration/*.js')
     .pipe(jasmine({
-      'includeStackTrace': true,
+      'includeStackTrace': false,
       'verbose': true,
       'timeout': 60000,
       'config': {
         'helpers': [
           './node_modules/babel-register/lib/node.js'
-        ]
+        ],
+        'random': false,
       }
     }));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,6 @@ const rename = require('gulp-rename');
 const insert = require('gulp-insert');
 const eslint = require('gulp-eslint');
 const jasmine = require('gulp-jasmine');
-const merge = require('merge-stream');
 const del = require('del');
 const VERSION = require('./package.json').version;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,7 +145,7 @@ gulp.task('unittest', (done, error) => {
     }));
 });
 
-gulp.task('test', gulp.series('unittest', 'integrationtest'));
+gulp.task('test', gulp.series('integrationtest', 'unittest'));
 
 gulp.task('jslint', function() {
   const buildVars = getBuildVars();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "gulp-replace-task": "^0.11.0",
     "gulp-uglify": "^3.0.2",
     "gulp-util": "^3.0.8",
-    "merge-stream": "^2.0.0",
     "jsdoc": "^3.4.1",
     "minami": "^1.1.1",
     "release-it": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-replace-task": "^0.11.0",
     "gulp-uglify": "^3.0.2",
     "gulp-util": "^3.0.8",
+    "merge-stream": "^2.0.0",
     "jsdoc": "^3.4.1",
     "minami": "^1.1.1",
     "release-it": "^2.9.0"


### PR DESCRIPTION
Since we are using `axios-mock-adapter` within unit tests which modifies the `adapter` attribute of default axios instance,   and we are mixing the running of integration tests and integration tests. So, once unit tests run before integration tests, integeration tests will fail then.  (`404 undefined undefined` response from axios.)

In this PR, I modified "gulp test" task to use 2 gulp.tasks (for integration test and unit test respectively) so that integration tests and unit tests run seperately.