### PR TITLE
add eslint to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "acorn": "^7.1.0",
     "axios-mock-adapter": "^1.16.0",
     "babel-eslint": "^10.0.1",
+    "eslint": "^4.12.1",
     "babelify": "^10.0.0",
     "del": "^2.0.2",
     "envify": "^3.4.0",


### PR DESCRIPTION
q8 reports: gulp-notify: [Error running Gulp] Error: Parsing error: Cannot find module 'eslint'