### PR TITLE
shift frame time

### DIFF
--- a/tests/integration/models-int-tests.js
+++ b/tests/integration/models-int-tests.js
@@ -271,7 +271,7 @@ describe('Integration Tests - Models', () => {
           expect(frame.frame_info.index).toBeDefined();
           expect(frame.frame_info.time).toBeDefined();
 
-          expect((frame.frame_info.time-1000) % 2000).toEqual(0);
+          expect((frame.frame_info.time+1000) % 2000).toEqual(0);
         }
 
         done();

--- a/tests/integration/models-int-tests.js
+++ b/tests/integration/models-int-tests.js
@@ -271,7 +271,7 @@ describe('Integration Tests - Models', () => {
           expect(frame.frame_info.index).toBeDefined();
           expect(frame.frame_info.time).toBeDefined();
 
-          expect(frame.frame_info.time % 2000).toEqual(0);
+          expect((frame.frame_info.time-1000) % 2000).toEqual(0);
         }
 
         done();


### PR DESCRIPTION
video frame timestamp will be midpoint time.
for example when sample_ms is 2000,
previously we return the frame time as:
0s, 2s, 4s ...
now we change to:
1s, 3s, 5s....
Making this change so the time is more accurate since ffmpeg using the midpoint.

