### PR TITLE
update for change in PR-12256

### DIFF
--- a/tests/integration/models-int-tests.js
+++ b/tests/integration/models-int-tests.js
@@ -63,12 +63,20 @@ describe('Integration Tests - Models', () => {
     done();
   });
 
-  it('Throws an error if no data found for training', done => {
-    expect(() => {
-      testModel.versionId = null;
-      testModel.train(true)
-    }).toThrow(new Error('No data found for training'));
-    done();
+  it('Gets status_code 21110 if train with no data', done => {
+    testModel.versionId = null;
+    testModel.train(true)
+      .then(model => {
+        expect(model).toBeDefined();
+        expect(model.modelVersion).toBeDefined();
+        expect(model.rawData).toBeDefined();
+        var version = model.modelVersion;
+        expect(version.id).toBeDefined();
+        expect(version.created_at).toBeDefined();
+        expect(version.status.code).toBe(21110);
+        done();
+      })
+      .catch(errorHandler.bind(done));
   });
 
   it('Adds inputs and trains the model', done => {

--- a/tests/integration/models-int-tests.js
+++ b/tests/integration/models-int-tests.js
@@ -63,20 +63,12 @@ describe('Integration Tests - Models', () => {
     done();
   });
 
-  it('Creates a new model version and returns after it has finished', done => {
-    testModel.versionId = null;
-    testModel.train(true)
-      .then(model => {
-        expect(model).toBeDefined();
-        expect(model.modelVersion).toBeDefined();
-        expect(model.rawData).toBeDefined();
-        var version = model.modelVersion;
-        expect(version.id).toBeDefined();
-        expect(version.created_at).toBeDefined();
-        expect(version.status.code).toBe(21100);
-        done();
-      })
-      .catch(errorHandler.bind(done));
+  it('Throws an error if no data found for training', done => {
+    expect(() => {
+      testModel.versionId = null;
+      testModel.train(true)
+    }).toThrow(new Error('No data found for training'));
+    done();
   });
 
   it('Adds inputs and trains the model', done => {


### PR DESCRIPTION
the models-int-test needs to be updated because of this recent commit in master:
https://github.com/Clarifai/clarifai/commit/2df06356d1e6e20a79b3c74ef68c552fd33251e6
The api-client-test is failing because it tries to train a model without any input (here: https://github.com/Clarifai/clarifai-javascript/blob/b9f3b02a38476da0cf56d7844112e3a51403285e/tests/integration/models-int-tests.js#L66).
In this PR, instead of checking that the new model-version is created, if an error is thrown is checked.