### PR TITLE
Add temporary test fix

### DIFF
--- a/tests/integration/models-int-tests.js
+++ b/tests/integration/models-int-tests.js
@@ -73,7 +73,7 @@ describe('Integration Tests - Models', () => {
         var version = model.modelVersion;
         expect(version.id).toBeDefined();
         expect(version.created_at).toBeDefined();
-        expect(version.status.code).toBe(21110);
+        expect(version.status.code == 21100 || version.status.code == 21110).toBe(true);
         done();
       })
       .catch(errorHandler.bind(done));


### PR DESCRIPTION
After merging https://github.com/Clarifai/clarifai-javascript/pull/50 , we have client tests failing on Production (because the code was not pushed there yet).

Let's temporarily allow both status codes.