### PR TITLE
[TP-674] Fail fast when `stage` is invalid.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,6 +97,10 @@ const lintOptions = {
 
 function getBuildVars() {
   const stageString = process.env.CLARIFAI_DEPLOY || gutil.env.stage || 'dev';
+  if (!buildVars.hasOwnProperty(stageString)) {
+    throw'There are no defined build variables for stage `' + stageString + '`';
+  }
+
   return buildVars[stageString];
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ const lintOptions = {
 function getBuildVars() {
   const stageString = process.env.CLARIFAI_DEPLOY || gutil.env.stage || 'dev';
   if (!buildVars.hasOwnProperty(stageString)) {
-    throw'There are no defined build variables for stage `' + stageString + '`';
+    throw 'There are no defined build variables for stage `' + stageString + '`';
   }
 
   return buildVars[stageString];


### PR DESCRIPTION
Running 
```
CLARIFAI_DEPLOY=local-k8s-marcelmoldovan
gulp jslint
```

BEFORE:
```
[12:22:47] Using gulpfile ~/work/clarifai-javascript/gulpfile.js
[12:22:47] Starting 'jslint'...
[12:22:47] 'jslint' errored after 1.45 ms
[12:22:47] TypeError: Cannot read property 'lintFailOnError' of undefined
```

AFTER:
```
[12:23:36] Using gulpfile ~/work/clarifai-javascript/gulpfile.js
[12:23:36] Starting 'jslint'...
[12:23:36] 'jslint' errored after 1.43 ms
[12:23:36] Error: There are no defined build variables for stage `local-k8s-marcelmoldovan`
```